### PR TITLE
updateTheater

### DIFF
--- a/src/main/java/com/example/mdb/controller/TheaterController.java
+++ b/src/main/java/com/example/mdb/controller/TheaterController.java
@@ -2,9 +2,9 @@ package com.example.mdb.controller;
 
 import com.example.mdb.dto.TheaterRequest;
 import com.example.mdb.dto.TheaterResponse;
+import com.example.mdb.dto.TheaterUpdateDTO;
 import com.example.mdb.entity.Theater;
 import com.example.mdb.exception.TheaterNotFoundException;
-import com.example.mdb.response.RestBuilder;
 import com.example.mdb.service.TheaterService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -22,8 +22,6 @@ import java.util.UUID;
 public class TheaterController {
 
     private final TheaterService theaterService;
-    private final RestBuilder restBuilder;
-
     private static final Logger logger = LoggerFactory.getLogger(TheaterController.class);
 
     // POST endpoint for creating a theater
@@ -34,34 +32,67 @@ public class TheaterController {
             TheaterResponse response = theaterService.createTheater(request);
 
             // Return success response with status and message
-            return restBuilder.success(HttpStatus.CREATED, "Theater created successfully", response);
+            return ResponseEntity.status(HttpStatus.CREATED).body(response);
         } catch (Exception e) {
             // Log the exception for debugging
             logger.error("Error occurred while creating the theater: ", e);
             // Return an error response in case of failure
-            return restBuilder.error(HttpStatus.BAD_REQUEST, "Failed to create theater", e.getMessage());
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body("Failed to create theater: " + e.getMessage());
         }
     }
 
     // GET endpoint for fetching a theater by its ID
-    @GetMapping("/theater")
-    public ResponseEntity<?> getTheaterById(@PathVariable String id) {
+    @GetMapping
+    public ResponseEntity<?> getTheaterById(@RequestParam String id) {
         try {
-            // Check if the ID is properly formatted as a UUID
-            if (!id.matches("^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$")) {
-                return ResponseEntity.status(HttpStatus.BAD_REQUEST).body("Invalid UUID format");
-            }
-
             // Convert the ID from String to UUID format
-            UUID theaterId = UUID.fromString(id);
+            UUID theaterId = UUID.fromString(id);  // Will throw IllegalArgumentException if invalid
 
             // Fetch the theater from the service
             Theater theater = theaterService.getTheaterById(theaterId);
 
-            return ResponseEntity.ok(theater);
+            // Return the theater in the response body
+            TheaterResponse response = new TheaterResponse(
+                    theater.getTheaterId().toString(),
+                    theater.getName(),
+                    theater.getAddress(),
+                    theater.getCity(),
+                    theater.getLandmark(),
+                    theater.getCreatedAt().toEpochMilli(),
+                    theater.getUpdatedAt().toEpochMilli(),
+                    theater.getCreatedBy().getEmail()
+            );
+            return ResponseEntity.ok(response);
         } catch (IllegalArgumentException e) {
+            // Handle invalid UUID format
             return ResponseEntity.status(HttpStatus.BAD_REQUEST).body("Invalid UUID format");
+        } catch (TheaterNotFoundException e) {
+            // Return 404 with a meaningful message if the theater is not found
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(e.getMessage());
         }
     }
-}
 
+    // PUT endpoint for updating a theater
+    @PutMapping("/{theaterId}")
+    public ResponseEntity<TheaterResponse> updateTheater(@PathVariable UUID theaterId,
+                                                         @RequestBody @Valid TheaterUpdateDTO theaterUpdateDTO) {
+        // Call the service to update the theater
+        Theater updatedTheater = theaterService.updateTheater(theaterId, theaterUpdateDTO);
+
+        // Map the updated theater to a response DTO
+        TheaterResponse response = new TheaterResponse(
+                updatedTheater.getTheaterId().toString(),
+                updatedTheater.getName(),
+                updatedTheater.getAddress(),
+                updatedTheater.getCity(),
+                updatedTheater.getLandmark(),
+                updatedTheater.getCreatedAt().toEpochMilli(),
+                updatedTheater.getUpdatedAt().toEpochMilli(),
+                updatedTheater.getCreatedBy().getEmail()
+        );
+
+        // Return the updated theater in the response
+        return ResponseEntity.ok(response);
+
+    }
+}

--- a/src/main/java/com/example/mdb/dto/TheaterUpdateDTO.java
+++ b/src/main/java/com/example/mdb/dto/TheaterUpdateDTO.java
@@ -1,0 +1,15 @@
+package com.example.mdb.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class TheaterUpdateDTO {
+    private String name;
+    private String address;
+    private String city;
+    private String landmark;
+
+
+}

--- a/src/main/java/com/example/mdb/repository/UserDetails/TheaterRepository.java
+++ b/src/main/java/com/example/mdb/repository/UserDetails/TheaterRepository.java
@@ -9,7 +9,6 @@ import java.util.Optional;
 import java.util.UUID;
 
 public interface TheaterRepository extends JpaRepository<Theater, UUID> {
-    @Query("SELECT t FROM Theater t WHERE HEX(t.theaterId) = :theaterId")
-    Optional<Theater> findByTheaterId(@Param("theaterId") String theaterId);
+    Optional<Theater> findByTheaterId(UUID theaterId);
 }
 

--- a/src/main/java/com/example/mdb/service/TheaterService.java
+++ b/src/main/java/com/example/mdb/service/TheaterService.java
@@ -2,6 +2,7 @@ package com.example.mdb.service;
 
 import com.example.mdb.dto.TheaterRequest;
 import com.example.mdb.dto.TheaterResponse;
+import com.example.mdb.dto.TheaterUpdateDTO;
 import com.example.mdb.entity.Theater;
 import com.example.mdb.entity.UserDetails;
 import com.example.mdb.exception.TheaterNotFoundException;
@@ -33,7 +34,6 @@ public class TheaterService {
         // Check if the user exists
         UserDetails user = userRepository.findByEmail(email)
                 .orElseThrow(() -> new UserNotFoundException("User with email " + email + " not found"));
-
 
         // Create a new theater
         Theater theater = new Theater();
@@ -71,11 +71,34 @@ public class TheaterService {
     }
 
     public Theater getTheaterById(UUID theaterId) {
-        String hexId = String.format("%032x", theaterId); // Convert UUID to hex string
-        return theaterRepository.findByTheaterId(hexId)
+        // Assuming the repository expects UUID, directly use UUID without converting to hex
+        return theaterRepository.findById(theaterId)  // Assuming `theaterRepository.findById` is using UUID as the key
                 .orElseThrow(() -> new TheaterNotFoundException("Theater with ID " + theaterId + " not found"));
     }
 
-    //Method to get a theater by ID
+    @Transactional
+    public Theater updateTheater(UUID theaterId , TheaterUpdateDTO theaterUpdateDTO){
+        Theater theater = theaterRepository.findByTheaterId(theaterId)
+                .orElseThrow(()-> new TheaterNotFoundException("Theater with ID"+theaterId+"not found"));
+
+        if (theaterUpdateDTO.getName() != null) {
+            theater.setName(theaterUpdateDTO.getName());
+        }
+        if (theaterUpdateDTO.getAddress() != null) {
+            theater.setAddress(theaterUpdateDTO.getAddress());
+        }
+        if (theaterUpdateDTO.getCity() != null) {
+            theater.setCity(theaterUpdateDTO.getCity());
+        }
+        if (theaterUpdateDTO.getLandmark() != null) {
+            theater.setLandmark(theaterUpdateDTO.getLandmark());
+        }
+
+        // Update the updated_at timestamp to the current time
+        theater.setUpdatedAt(Instant.now());
+
+        // Save the updated theater back to the database
+        return theaterRepository.save(theater);  // This should return the updated Theater entity
+    }
 
 }


### PR DESCRIPTION
#Description
Update Theater API
This API allows users to update theater information, including details such as name, address, city, and landmark. The request is processed via a PUT method where the theater is identified by a unique UUID. If the theater exists, it is updated with the new data and the timestamp for the last update is automatically set. This feature ensures secure and efficient modification of theater records.